### PR TITLE
Fix riscv_qemu to work on qemu 7.x

### DIFF
--- a/src/core/board/riscv_qemu/plic.h
+++ b/src/core/board/riscv_qemu/plic.h
@@ -18,14 +18,42 @@ namespace Board { class Plic; }
 
 struct Board::Plic : Genode::Mmio
 {
-		enum { NR_OF_IRQ = 32 };
+		enum {
+			/*
+			 * Single core Qemu virt machine uses context 1 for
+			 * supervisor mode interrupts and 0 for machine mode.
+			 */
+			CONTEXT   = 0x1,
+			/*
+			 * VIRT_IRQCHIP_NUM_SOURCES from Qemu include/hw/riscv/virt.h.
+			 */
+			NR_OF_IRQ = 96,
+		};
+		enum {
+			ENABLE_BASE    = 0x2000,
+			ENABLE_STRIDE  = 0x80,
+			CONTEXT_BASE   = 0x200000,
+			CONTEXT_STRIDE = 0x1000,
+		};
+		enum {
+			ENABLE_ADDR   = ENABLE_BASE + CONTEXT * ENABLE_STRIDE,
+			PRI_THR_ADDR  = CONTEXT_BASE + CONTEXT * CONTEXT_STRIDE,
+			ID_ADDR       = CONTEXT_BASE + CONTEXT * CONTEXT_STRIDE + 0x4,
+		};
 
-		struct Enable : Register_array<0x80, 32, 32, 1> { };
-		struct Id     : Register<0x1ff004, 32> { };
+		struct Priority           : Register_array<0x4, 32, NR_OF_IRQ - 1, 32> { };
+		struct Enable             : Register_array<ENABLE_ADDR, 32, NR_OF_IRQ, 1> { };
+		struct Priority_threshold : Register<PRI_THR_ADDR, 32> { };
+		struct Id                 : Register<ID_ADDR, 32> { };
 
 		Plic(Genode::addr_t const base)
 		:
-			Mmio(base) { }
+			Mmio(base)
+		{
+			write<Priority_threshold>(0);
+			for (unsigned i = 0; i < NR_OF_IRQ - 1; ++i)
+				write<Priority>(1, i);
+		}
 
 		void enable(unsigned value, unsigned irq)
 		{

--- a/src/include/hw/spec/riscv/qemu_board.h
+++ b/src/include/hw/spec/riscv/qemu_board.h
@@ -26,8 +26,8 @@ namespace Hw::Riscv_board {
 		RAM_SIZE = 0x1ffc0000,
 		TIMER_HZ = 10000000,
 
-		PLIC_BASE = 0xc002000,
-		PLIC_SIZE = 0x200000,
+		PLIC_BASE = 0xc000000,
+		PLIC_SIZE = 0x202000,
 	};
 
 	enum { UART_BASE, UART_CLOCK };

--- a/src/include/hw/spec/riscv/qemu_board.h
+++ b/src/include/hw/spec/riscv/qemu_board.h
@@ -22,8 +22,8 @@
 namespace Hw::Riscv_board {
 
 	enum {
-		RAM_BASE = 0x80020000,
-		RAM_SIZE = 0x1ffe0000,
+		RAM_BASE = 0x80040000,
+		RAM_SIZE = 0x1ffc0000,
 		TIMER_HZ = 10000000,
 
 		PLIC_BASE = 0xc002000,


### PR DESCRIPTION
This is a collection of two small patches that makes it possible to run Genode riscv_qemu on Qemu version 7.x.